### PR TITLE
Require phpunit for developers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,16 @@
     "description": "The Action-Domain-Responder core library for Radar.",
     "type": "library",
     "license": "MIT",
+    "minimum-stability": "dev",
     "require": {
         "aura/di": "~3.0",
         "aura/payload": "~3.0",
         "aura/router": "~3.0",
         "josegonzalez/dotenv": "~0.0",
         "phly/http": "~0.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8@dev"
     },
     "autoload": {
         "psr-4": {
@@ -20,6 +24,5 @@
             "Radar\\Adr\\": "tests/",
             "Aura\\Di\\_Config\\": "vendor/aura/di/tests/_Config"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Not sure why this was omitted from `composer.json`.
