### PR TITLE
update to make use of aura di, payload, router to alpha versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "aura/di": "~3.0",
-        "aura/payload": "~3.0",
-        "aura/router": "~3.0",
+        "aura/di": "~3.0.0@alpha",
+        "aura/payload": "~3.0.0@alpha",
+        "aura/router": "~3.0.0@alpha",
         "josegonzalez/dotenv": "~0.0"
     },
     "require-dev": {
@@ -22,6 +22,5 @@
             "Radar\\Adr\\": "tests/",
             "Aura\\Di\\_Config\\": "vendor/aura/di/tests/_Config"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
The user can change the minimum-stability flag to dev, alpha, beta so that the versions of the dependencies will be installed accordingly.

Please make sure you tag a new release for Aura.Payload for the current releases of Payload all point to the dependency on dev . You can have a look at this tweet https://twitter.com/padraicb/status/600257934216589312 .

Thank you.
