### PR TITLE
Removed a redundant return in Resolver->__invoke()

### DIFF
--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -20,7 +20,6 @@ class Resolver
 
         if (is_array($spec) && is_string($spec[0])) {
             $spec[0] = $this->injectionFactory->newInstance($spec[0]);
-            return $spec;
         }
 
         return $spec;


### PR DESCRIPTION
The return $spec; statement in the last conditional is redundant with respect to the one immediately following the conditional block.
