### PR TITLE
Add param for fail responder in RoutingHandler

### DIFF
--- a/src/Handler/RoutingHandler.php
+++ b/src/Handler/RoutingHandler.php
@@ -11,11 +11,13 @@ class RoutingHandler
 {
     protected $actionFactory;
     protected $matcher;
+    protected $failResponder;
 
-    public function __construct(Matcher $matcher, ActionFactory $actionFactory)
+    public function __construct(Matcher $matcher, ActionFactory $actionFactory, $failResponder = null)
     {
         $this->matcher = $matcher;
         $this->actionFactory = $actionFactory;
+        $this->failResponder = $failResponder ?: 'Radar\Adr\Responder\RoutingFailedResponder';
     }
 
     public function __invoke(Request $request, Response $response, callable $next)
@@ -34,7 +36,7 @@ class RoutingHandler
                 $this->actionFactory->newInstance(
                     null,
                     [$this->matcher, 'getFailedRoute'],
-                    'Radar\Adr\Responder\RoutingFailedResponder'
+                    $this->failResponder
                 )
             );
         }

--- a/tests/Fake/FakeRoutingFailedResponder.php
+++ b/tests/Fake/FakeRoutingFailedResponder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Radar\Adr\Responder;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Radar\Adr\Route;
+
+use Radar\Adr\Responder\RoutingFailedResponder;
+
+class FakeRoutingFailedResponder extends RoutingFailedResponder
+{
+}

--- a/tests/Handler/RoutingHandlerTest.php
+++ b/tests/Handler/RoutingHandlerTest.php
@@ -78,4 +78,37 @@ class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
 
         return $response;
     }
+
+    public function testCustomNotFound()
+    {
+        $routingHandler = new RoutingHandler(
+            $this->matcher,
+            new ActionFactory(),
+            'Radar\Adr\Fake\FakeRoutingFailedResponder'
+        );
+
+        $this->map->get('Radar\Adr\Fake\Action', '/fake/{id}', 'FakeDomain');
+        $request = $this->newRequest('/wrong/path');
+        $response = new Response();
+        $returnedResponse = $routingHandler->__invoke(
+            $request,
+            $response,
+            [$this, 'assertCustomNotFound']
+        );
+    }
+
+    public function assertCustomNotFound($request, $response)
+    {
+        $action = $request->getAttribute('radar/adr:action');
+        $this->assertSame(
+            'Radar\Adr\Fake\FakeRoutingFailedResponder',
+            $action->getResponder()
+        );
+
+        $expect = $this->matcher->getFailedRoute();
+        $actual = call_user_func($action->getDomain());
+        $this->assertSame($expect, $actual);
+
+        return $response;
+    }
 }


### PR DESCRIPTION
> Add ability to pass $failResponder to RoutingHandler and specify a custom class
> in place of RoutingFailedResponder

Maybe I'm thinking about this wrong, but I felt like I wanted the ability to
override the default routing failed responses, and thought this would be
sufficient as oppose to having to always extend the `RoutingHandler` itself.

Thoughts?
