### PR TITLE
Fix test to match Responder class.

### DIFF
--- a/tests/Responder/ResponderTest.php
+++ b/tests/Responder/ResponderTest.php
@@ -151,7 +151,7 @@ class ResponderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertPayloadResponse(
             $payload,
-            400,
+            401,
             ['Content-Type' => 'application/json'],
             '{"foo":"bar"}'
         );


### PR DESCRIPTION
Authentication needed should be 401, not 400, to my understanding.

> 401 Unauthorized (RFC 7235)
> Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource. See Basic access authentication and Digest access authentication.
