### PR TITLE
Combined fix for previous PRs #20 and #21.

### DIFF
--- a/src/Responder/Responder.php
+++ b/src/Responder/Responder.php
@@ -96,7 +96,7 @@ class Responder implements ResponderAcceptsInterface
 
     protected function notAuthenticated()
     {
-        $this->response = $this->response->withStatus(400);
+        $this->response = $this->response->withStatus(401);
         $this->jsonBody($this->payload->getInput());
     }
 

--- a/tests/Responder/ResponderTest.php
+++ b/tests/Responder/ResponderTest.php
@@ -151,7 +151,7 @@ class ResponderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertPayloadResponse(
             $payload,
-            400,
+            401,
             ['Content-Type' => 'application/json'],
             '{"foo":"bar"}'
         );


### PR DESCRIPTION
The status 400 is in error.  A request needing authentication should return HTTP status 401, if I understand the standard correctly.

From Wikipedia:
401 Unauthorized (RFC 7235)
Similar to 403 Forbidden, but specifically for use when authentication is required and has failed or has not yet been provided. The response must include a WWW-Authenticate header field containing a challenge applicable to the requested resource. See Basic access authentication and Digest access authentication.
