### PR TITLE
Remove use josegonzalez\Dotenv\Loader;

### DIFF
--- a/src/Boot.php
+++ b/src/Boot.php
@@ -2,7 +2,6 @@
 namespace Radar\Adr;
 
 use Aura\Di\ContainerBuilder;
-use josegonzalez\Dotenv\Loader;
 
 class Boot
 {


### PR DESCRIPTION
josegonzalez\Dotenv\Loader isn't used in this class anymore, removed the use statement at the top.
