### PR TITLE
PSR15 lamba style middleware branch?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,19 @@
     "type": "library",
     "homepage": "https://github.com/radarphp/Radar.Adr",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/jakejohns/Arbiter.Arbiter"
+        }
+    ],
     "require": {
         "aura/di": "~3.0",
         "aura/payload": "~3.0",
         "aura/router": "~3.0",
-        "relay/relay": "~1.0",
-        "relay/middleware": "~1.0",
-        "arbiter/arbiter": "~1.0"
+        "telegraph/telegraph": "~1.0",
+        "telegraph/middleware": "~1.0",
+        "arbiter/arbiter": "dev-feature/psr-15"
     },
     "require-dev": {
         "zendframework/zend-diactoros": "~1.0"

--- a/src/Adr.php
+++ b/src/Adr.php
@@ -12,12 +12,12 @@ use Aura\Router\Map;
 use Aura\Router\Rule\RuleIterator;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Relay\RelayBuilder;
+use Telegraph\TelegraphFactory;
 
 /**
  *
  * The "main" class for building and running the router and the middleware
- * relay.
+ * telegraph.
  *
  * @package radar/adr
  *
@@ -44,12 +44,12 @@ class Adr
 
     /**
      *
-     * The middleware relay builder.
+     * The middleware telegraph factory.
      *
-     * @var RelayBuilder
+     * @var TelegraphFactory
      *
      */
-    protected $relayBuilder;
+    protected $telegraphFactory;
 
     /**
      *
@@ -62,23 +62,36 @@ class Adr
 
     /**
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+     */
+    protected $resolver;
+
+    /**
+     *
      * Constructor.
      *
      * @param Map $map The router map.
      *
      * @param RuleIterator $rules The route-matching rules.
      *
-     * @param RelayBuilder $relayBuilder The middleware relay builder.
+     * @param TelegraphFactory $telegraphFactory The middleware telegraph builder.
+     *
+     * @param callable $resolver The resolver.
      *
      */
     public function __construct(
         Map $map,
         RuleIterator $rules,
-        RelayBuilder $relayBuilder
+        TelegraphFactory $telegraphFactory,
+        callable $resolver = null
     ) {
         $this->map = $map;
         $this->rules = $rules;
-        $this->relayBuilder = $relayBuilder;
+        $this->telegraphFactory = $telegraphFactory;
+        $this->resolver = $resolver;
     }
 
     /**
@@ -132,9 +145,11 @@ class Adr
      * @return Response
      *
      */
-    public function run(Request $request, Response $response)
+    public function run(Request $request)
     {
-        $relay = $this->relayBuilder->newInstance($this->middle);
-        return $relay($request, $response);
+        $telegraph = $this->telegraphFactory->newInstance(
+            $this->middle, $this->resolver
+        );
+        return $telegraph->dispatch($request);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,16 +42,12 @@ class Config extends ContainerConfig
         $di->setters['Aura\Router\RouterContainer']['setRouteFactory'] = $di->newFactory('Radar\Adr\Route');
 
         /**
-         * Relay\RelayBuilder
-         */
-        $di->params['Relay\RelayBuilder']['resolver'] = $di->lazyGet('radar/adr:resolver');
-
-        /**
          * Radar\Adr\Adr
          */
         $di->params['Radar\Adr\Adr']['map'] = $di->lazyGetCall('radar/adr:router', 'getMap');
         $di->params['Radar\Adr\Adr']['rules'] = $di->lazyGetCall('radar/adr:router', 'getRuleIterator');
-        $di->params['Radar\Adr\Adr']['relayBuilder'] = $di->lazyNew('Relay\RelayBuilder');
+        $di->params['Radar\Adr\Adr']['telegraphFactory'] = $di->lazyNew('Telegraph\TelegraphFactory');
+        $di->params['Radar\Adr\Adr']['resolver'] = $di->lazyGet('radar/adr:resolver');
 
         /**
          * Radar\Adr\Handler\ActionHandler

--- a/src/Handler/ActionHandler.php
+++ b/src/Handler/ActionHandler.php
@@ -9,7 +9,6 @@
 namespace Radar\Adr\Handler;
 
 use Arbiter\ActionHandler as Arbiter;
-use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
 /**
@@ -28,21 +27,14 @@ class ActionHandler extends Arbiter
      *
      * @param Request $request The HTTP request object.
      *
-     * @param Response $response The HTTP response object.
-     *
-     * @param callable $next The next middleware decorator.
-     *
      * @return Response
      *
      */
     public function __invoke(
-        Request $request,
-        Response $response,
-        callable $next
+        Request $request
     ) {
         $action = $request->getAttribute('radar/adr:action');
         $request = $request->withoutAttribute('radar/adr:action');
-        $response = $this->handle($action, $request, $response);
-        return $next($request, $response);
+        return $this->handle($action, $request);
     }
 }

--- a/src/Handler/RoutingHandler.php
+++ b/src/Handler/RoutingHandler.php
@@ -78,8 +78,6 @@ class RoutingHandler
      *
      * @param Request $request The HTTP request object.
      *
-     * @param Response $response The HTTP response object.
-     *
      * @param callable $next The next middleware decorator.
      *
      * @return Response
@@ -87,12 +85,11 @@ class RoutingHandler
      */
     public function __invoke(
         Request $request,
-        Response $response,
         callable $next
     ) {
         $route = $this->matcher->match($request);
         $request = $this->addRouteToRequest($route, $request);
-        return $next($request, $response);
+        return $next($request);
     }
 
     /**

--- a/src/Responder/AbstractResponder.php
+++ b/src/Responder/AbstractResponder.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *
+ * This file is part of Radar for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Radar\Adr\Responder;
+
+use Psr\Http\Message\ResponseInterface as Response;
+
+/**
+ *
+ * An Abstract Responder.
+ *
+ * @package radar/adr
+ *
+ */
+abstract class AbstractResponder
+{
+    /**
+     *
+     * The HTTP response.
+     *
+     * @var Response
+     *
+     */
+    protected $response;
+
+    /**
+     * __construct
+     *
+     * @param Response $response PSR7 Response
+     *
+     * @access public
+     */
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Responder/Responder.php
+++ b/src/Responder/Responder.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\ResponseInterface as Response;
  * @package radar/adr
  *
  */
-class Responder implements ResponderAcceptsInterface
+class Responder extends AbstractResponder implements ResponderAcceptsInterface
 {
     /**
      *
@@ -39,15 +39,6 @@ class Responder implements ResponderAcceptsInterface
      *
      */
     protected $request;
-
-    /**
-     *
-     * The HTTP response.
-     *
-     * @var Response
-     *
-     */
-    protected $response;
 
     /**
      *
@@ -76,11 +67,9 @@ class Responder implements ResponderAcceptsInterface
      */
     public function __invoke(
         Request $request,
-        Response $response,
         PayloadInterface $payload = null
     ) {
         $this->request = $request;
-        $this->response = $response;
         $this->payload = $payload;
         $method = $this->getMethodForPayload();
         $this->$method();

--- a/src/Responder/RoutingFailedResponder.php
+++ b/src/Responder/RoutingFailedResponder.php
@@ -19,7 +19,7 @@ use Radar\Adr\Route;
  * @package radar/adr
  *
  */
-class RoutingFailedResponder
+class RoutingFailedResponder extends AbstractResponder
 {
     /**
      *
@@ -54,8 +54,6 @@ class RoutingFailedResponder
      *
      * @param Request $request The HTTP request object.
      *
-     * @param Response $response The HTTP response object.
-     *
      * @param Route $failedRoute The closest route that failed to match.
      *
      * @return Response
@@ -63,11 +61,9 @@ class RoutingFailedResponder
      */
     public function __invoke(
         Request $request,
-        Response $response,
         Route $failedRoute
     ) {
         $this->request = $request;
-        $this->response = $response;
         $this->failedRoute = $failedRoute;
         $method = $this->getMethodForFailedRoute();
         $this->$method();

--- a/tests/AdrTest.php
+++ b/tests/AdrTest.php
@@ -5,7 +5,7 @@ use Aura\Di\ContainerBuilder;
 use Aura\Router\Rule\RuleIterator;
 use Radar\Adr\Fake\FakeMiddleware;
 use Radar\Adr\Route;
-use Relay\RelayBuilder;
+use Telegraph\TelegraphFactory;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 
@@ -21,12 +21,13 @@ class AdrTest extends \PHPUnit_Framework_TestCase
 
         $this->fakeMap = new Fake\FakeMap(new Route());
         $this->fakeRules = new RuleIterator();
-        $this->relayBuilder = new RelayBuilder($resolver);
+        $this->telegraph = new TelegraphFactory();
 
         $this->adr = new Adr(
             $this->fakeMap,
             $this->fakeRules,
-            $this->relayBuilder
+            $this->telegraph,
+            $resolver
         );
     }
 
@@ -49,13 +50,13 @@ class AdrTest extends \PHPUnit_Framework_TestCase
         $this->adr->middle('Radar\Adr\Fake\FakeMiddleware');
         $this->adr->middle('Radar\Adr\Fake\FakeMiddleware');
         $this->adr->middle('Radar\Adr\Fake\FakeMiddleware');
+        $this->adr->middle('Radar\Adr\Fake\FakeResponseMiddleware');
 
         $response = $this->adr->run(
-            ServerRequestFactory::fromGlobals(),
-            new Response()
+            ServerRequestFactory::fromGlobals()
         );
 
         $actual = (string) $response->getBody();
-        $this->assertSame('123456', $actual);
+        $this->assertSame('123', $actual);
     }
 }

--- a/tests/Fake/Action/Responder.php
+++ b/tests/Fake/Action/Responder.php
@@ -3,8 +3,9 @@ namespace Radar\Adr\Fake\Action;
 
 use Aura\Payload_Interface\PayloadInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Message\ResponseInterface as Response;
 use Radar\Adr\Responder\ResponderAcceptsInterface;
+
+use Zend\Diactoros\Response;
 
 class Responder implements ResponderAcceptsInterface
 {
@@ -13,16 +14,20 @@ class Responder implements ResponderAcceptsInterface
         return ['foo/bar'];
     }
 
+    public function __construct()
+    {
+        $this->response = new Response;
+    }
+
     public function __invoke(
         Request $request,
-        Response $response,
         PayloadInterface $payload = null
     ) {
         if ($payload) {
-            $response->getBody()->write($payload->getOutput());
+            $this->response->getBody()->write($payload->getOutput());
         } else {
-            $response->getBody()->write('No payload.');
+            $this->response->getBody()->write('No payload.');
         }
-        return $response;
+        return $this->response;
     }
 }

--- a/tests/Fake/FakeMiddleware.php
+++ b/tests/Fake/FakeMiddleware.php
@@ -1,14 +1,15 @@
 <?php
 namespace Radar\Adr\Fake;
 
+use Zend\Diactoros\Response;
+
 class FakeMiddleware
 {
     public static $count;
 
-    public function __invoke($request, $response, $next)
+    public function __invoke($request, $next)
     {
-        $response->getBody()->write(++ static::$count);
-        $response = $next($request, $response);
+        $response = $next($request);
         $response->getBody()->write(++ static::$count);
         return $response;
     }

--- a/tests/Fake/FakeResponseMiddleware.php
+++ b/tests/Fake/FakeResponseMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+namespace Radar\Adr\Fake;
+
+use Zend\Diactoros\Response;
+
+class FakeResponseMiddleware
+{
+
+    public function __invoke($request, $next)
+    {
+        return new Response;
+    }
+}

--- a/tests/Handler/ActionHandlerTest.php
+++ b/tests/Handler/ActionHandlerTest.php
@@ -16,6 +16,8 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $di = $builder->newInstance();
+        $di->params['Radar\Adr\Responder\AbstractResponder']
+            ['response'] = $di->lazyNew('Zend\Diactoros\Response');
         $this->actionHandler = new ActionHandler(
             new Resolver($di->getInjectionFactory())
         );
@@ -27,8 +29,7 @@ class ActionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = $request->withAttribute('radar/adr:action', $action);
         $response = $this->actionHandler->__invoke(
             $request,
-            new Response(),
-            function ($request, $response) { return $response; }
+            function ($request) { return; }
         );
         $this->assertEquals($expectStatus, $response->getStatusCode());
         $this->assertEquals($expectBody, $response->getBody()->__toString());

--- a/tests/Handler/RoutingHandlerTest.php
+++ b/tests/Handler/RoutingHandlerTest.php
@@ -34,37 +34,30 @@ class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->map->get('Radar\Adr\Fake\Action', '/fake/{id}', 'FakeDomain');
         $request = $this->newRequest('/fake/88');
-        $response = new Response();
-        $returnedResponse = $this->routingHandler->__invoke(
+        $this->routingHandler->__invoke(
             $request,
-            $response,
             [$this, 'assertFound']
         );
-        $this->assertSame($response, $returnedResponse);
     }
 
-    public function assertFound($request, $response)
+    public function assertFound($request)
     {
         $action = $request->getAttribute('radar/adr:action');
         $id = $request->getAttribute('id');
         $this->assertSame('88', $id);
-        return $response;
     }
 
     public function testNotFound()
     {
         $this->map->get('Radar\Adr\Fake\Action', '/fake/{id}', 'FakeDomain');
         $request = $this->newRequest('/wrong/path');
-        $response = new Response();
         $returnedResponse = $this->routingHandler->__invoke(
             $request,
-            $response,
             [$this, 'assertNotFound']
         );
-        $this->assertSame($response, $returnedResponse);
     }
 
-    public function assertNotFound($request, $response)
+    public function assertNotFound($request)
     {
         $action = $request->getAttribute('radar/adr:action');
         $this->assertSame(
@@ -75,8 +68,6 @@ class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
         $expect = $this->matcher->getFailedRoute();
         $actual = call_user_func($action->getDomain());
         $this->assertSame($expect, $actual);
-
-        return $response;
     }
 
     public function testCustomNotFound()
@@ -89,15 +80,13 @@ class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->map->get('Radar\Adr\Fake\Action', '/fake/{id}', 'FakeDomain');
         $request = $this->newRequest('/wrong/path');
-        $response = new Response();
         $returnedResponse = $routingHandler->__invoke(
             $request,
-            $response,
             [$this, 'assertCustomNotFound']
         );
     }
 
-    public function assertCustomNotFound($request, $response)
+    public function assertCustomNotFound($request)
     {
         $action = $request->getAttribute('radar/adr:action');
         $this->assertSame(
@@ -108,7 +97,5 @@ class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
         $expect = $this->matcher->getFailedRoute();
         $actual = call_user_func($action->getDomain());
         $this->assertSame($expect, $actual);
-
-        return $response;
     }
 }

--- a/tests/Responder/ResponderTest.php
+++ b/tests/Responder/ResponderTest.php
@@ -13,7 +13,7 @@ class ResponderTest extends \PHPUnit_Framework_TestCase
 
     public function setup()
     {
-        $this->responder = new Responder();
+        $this->responder = new Responder(new Response);
     }
 
     public function testAccepts()
@@ -26,10 +26,9 @@ class ResponderTest extends \PHPUnit_Framework_TestCase
     protected function getResponse($payload)
     {
         $request = ServerRequestFactory::fromGlobals();
-        $response = new Response();
         return $payload
-            ? $this->responder->__invoke($request, $response, $payload)
-            : $this->responder->__invoke($request, $response);
+            ? $this->responder->__invoke($request, $payload)
+            : $this->responder->__invoke($request);
     }
 
     protected function assertPayloadResponse($payload, $status, array $headers, $body)

--- a/tests/Responder/RoutingFailedResponderTest.php
+++ b/tests/Responder/RoutingFailedResponderTest.php
@@ -9,10 +9,9 @@ class RoutingFailedResponderTest extends \PHPUnit_Framework_TestCase
 {
     protected function getResponse($failedRoute)
     {
-        $routingFailedResponder = new RoutingFailedResponder();
+        $routingFailedResponder = new RoutingFailedResponder(new Response);
         $request = ServerRequestFactory::fromGlobals();
-        $response = new Response();
-        return $routingFailedResponder($request, $response, $failedRoute);
+        return $routingFailedResponder($request, $failedRoute);
     }
 
     protected function assertResponse($failedRoute, $status, array $headers, $body)


### PR DESCRIPTION
Do we need/want a PSR15 (ie. Telegraph branch/fork/whatever)?
Is PSR15 going to be the future?

One thing I wasn't sure about (and also pertains to arbiterphp/Arbiter.Arbiter#5 ) was if the `Responder` should have a dependency on the `Response` or if the handler should be something more like:

``` php

public function __invoke($request, $next)
{
    $action   = $request->getAttribute('radar/adr:action');
    $request  = $request->withoutAttribute('radar/adr:action');
    $response = $next($request); // before? after?
    return $this->handle($action, $request, $response);
}

```

This would assume some "Final Response Factory Middleware"i that would probably
be part of `Telegraph\Middleware`, ie:
(  telegraphp/telegraph.middleware#2 ) 

``` php
public function __invoke($request, $next)
{
    return new Response;
}

```

This would also mean the handler for Arbiter would not be like what currently
is present in the above mentioned fork/pr.
