### PR TITLE
Fix Travis PHP 7 unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.6
   - 7
 before_script:
+  - curl -sSfL -o ~/.phpenv/versions/$(phpenv 7e)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
   - composer self-update
   - composer install
 script:

--- a/tests/AdrTest.php
+++ b/tests/AdrTest.php
@@ -9,7 +9,7 @@ use Relay\RelayBuilder;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 
-class AdrTest extends \PHPUnit_Framework_TestCase
+class AdrTest extends \PHPUnit\Framework\TestCase
 {
     protected $adr;
 

--- a/tests/BootTest.php
+++ b/tests/BootTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Radar\Adr;
 
-class BootTest extends \PHPUnit_Framework_TestCase
+class BootTest extends \PHPUnit\Framework\TestCase
 {
     protected $containerCache;
 

--- a/tests/Handler/ActionHandlerTest.php
+++ b/tests/Handler/ActionHandlerTest.php
@@ -8,7 +8,7 @@ use Radar\Adr\Route;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 
-class ActionHandlerTest extends \PHPUnit_Framework_TestCase
+class ActionHandlerTest extends \PHPUnit\Framework\TestCase
 {
     protected $actionHandler;
 

--- a/tests/Handler/RoutingHandlerTest.php
+++ b/tests/Handler/RoutingHandlerTest.php
@@ -8,7 +8,7 @@ use Radar\Adr\Route;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 
-class RoutingHandlerTest extends \PHPUnit_Framework_TestCase
+class RoutingHandlerTest extends \PHPUnit\Framework\TestCase
 {
     protected $map;
     protected $matcher;

--- a/tests/Responder/ResponderTest.php
+++ b/tests/Responder/ResponderTest.php
@@ -6,7 +6,7 @@ use Aura\Payload_Interface\PayloadStatus;
 use Zend\Diactoros\ServerRequestFactory;
 use Zend\Diactoros\Response;
 
-class ResponderTest extends \PHPUnit_Framework_TestCase
+class ResponderTest extends \PHPUnit\Framework\TestCase
 {
     protected $responder;
     protected $payload;

--- a/tests/Responder/RoutingFailedResponderTest.php
+++ b/tests/Responder/RoutingFailedResponderTest.php
@@ -5,7 +5,7 @@ use Zend\Diactoros\ServerRequestFactory;
 use Zend\Diactoros\Response;
 use Radar\Adr\Route;
 
-class RoutingFailedResponderTest extends \PHPUnit_Framework_TestCase
+class RoutingFailedResponderTest extends \PHPUnit\Framework\TestCase
 {
     protected function getResponse($failedRoute)
     {


### PR DESCRIPTION
Namespaced test class names are backward compatible, and should work for both PHP 5.6 and PHP 7.